### PR TITLE
EB config fix

### DIFF
--- a/.ebextensions/02_python.config
+++ b/.ebextensions/02_python.config
@@ -4,7 +4,7 @@ container_commands:
 
 option_settings:
   "aws:elasticbeanstalk:application:environment":
-    DJANGO_SETTINGS_MODULE: "bigmoney.settings_eb_staging"
+    DJANGO_SETTINGS_MODULE: "bigmoney.settings"
     "PYTHONPATH": "/opt/python/current/app/bigmoney:$PYTHONPATH"
   "aws:elasticbeanstalk:container:python":
     WSGIPath: bigmoney/bigmoney/wsgi.py


### PR DESCRIPTION
There was a single reference to the 'settings_eb_staging' file leftover from the settings cleanup (commit bf334ca). This commit updates the python config in .ebextensions so that it points to the correct file instead.